### PR TITLE
feat: initial landing page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# dependencies
+/node_modules
+
+# production
+/.next
+/out
+
+# misc
+.env.local
+.env*.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.next
+dist
+
+# editor
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# TMS-Football-Shop-Berlin
-Landing page of TMS Football Shop Berlin
+# TMS Footballshop Berlin — Landing Page
+
+A modern, fast landing page that links out to Shopify and services.
+
+## Tech
+- Next.js (App Router, TS)
+- Tailwind CSS
+
+## Develop
+```bash
+npm install
+npm run dev
+```
+
+## Build & Run
+
+```bash
+npm run build
+npm start
+```
+
+## Configure
+
+* Replace Shopify URLs in `src/data/nav.json` and `src/data/sales.json`.
+* Edit promos/announcement in `src/data/sales.json`.
+* Update social links in `src/data/nav.json`.
+

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'images.unsplash.com' }
+    ]
+  }
+};
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "tms-footballshop-landing",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.12",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.7",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import "../styles/globals.css";
+import AnnouncementBar from "@/components/AnnouncementBar";
+import Navbar from "@/components/Navbar";
+import SocialFloat from "@/components/SocialFloat";
+
+export const metadata = {
+  title: "TMS Footballshop Berlin",
+  description: "Ausrüstung, Service & Beratung — Berlin",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="de">
+      <body className="antialiased">
+        <AnnouncementBar />
+        <Navbar />
+        <SocialFloat />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,42 @@
+import Hero from "@/components/Hero";
+import PromoSpotlight from "@/components/PromoSpotlight";
+import SalesButton from "@/components/SalesButton";
+import SalesModal from "@/components/SalesModal";
+
+export default function Page() {
+  return (
+    <>
+      <Hero />
+      <PromoSpotlight />
+
+      {/* Services anchors for dropdown links */}
+      <section id="service-ozone" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-2xl font-bold">O-Zone Power Cleaning</h2>
+        <p className="mt-2 text-gray-600">Geruchsbeseitigung & Hygienereinigung für Ausrüstung.</p>
+      </section>
+
+      <section id="service-consulting" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-2xl font-bold">Consulting</h2>
+        <p className="mt-2 text-gray-600">Team- und Spielerberatung, Größen- und Safety-Check.</p>
+      </section>
+
+      <section id="service-reconditioning" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-2xl font-bold">Reconditioning</h2>
+        <p className="mt-2 text-gray-600">Inspektion, Reparatur, Lackierung, Zertifizierung.</p>
+      </section>
+
+      <section id="gallery" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-2xl font-bold">Gallery</h2>
+        <p className="mt-2 text-gray-600">Vorher/Nachher Bilder und Projekte (bald verfügbar).</p>
+      </section>
+
+      <section id="contact" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-2xl font-bold">Contact Us</h2>
+        <p className="mt-2 text-gray-600">Schreib uns oder besuch uns im Shop. Öffnungszeiten folgen.</p>
+      </section>
+
+      <SalesButton />
+      <SalesModal />
+    </>
+  );
+}

--- a/src/components/AnnouncementBar.tsx
+++ b/src/components/AnnouncementBar.tsx
@@ -1,0 +1,10 @@
+import sales from "@/data/sales.json";
+
+export default function AnnouncementBar() {
+  if (!sales.announcement) return null;
+  return (
+    <div className="bg-amber-100 text-amber-900 text-center text-sm py-2">
+      {sales.announcement}
+    </div>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,28 @@
+import nav from "@/data/nav.json";
+
+export default function Hero() {
+  return (
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-black via-zinc-800 to-black opacity-80" />
+      <img
+        src="https://images.unsplash.com/photo-1513171920216-2640b288471b?q=80&w=2000&auto=format&fit=crop"
+        alt="American Football gear background"
+        className="absolute inset-0 h-full w-full object-cover"
+      />
+      <div className="relative mx-auto max-w-6xl px-4 py-28 text-white">
+        <h1 className="text-4xl md:text-6xl font-extrabold leading-tight">Gear up for the Season.</h1>
+        <p className="mt-4 max-w-xl text-lg md:text-xl opacity-90">
+          Pro Ausrüstung, Service & Beratung — schnell, sicher, zuverlässig.
+        </p>
+        <div className="mt-8 flex items-center gap-3">
+          <a href={nav.shop.href} className="rounded-full bg-white text-black px-5 py-3 font-semibold hover:opacity-90">
+            Zum Shop
+          </a>
+          <a href="/#service-reconditioning" className="rounded-full border border-white px-5 py-3 font-semibold hover:bg-white/10">
+            Services ansehen
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import nav from "@/data/nav.json";
+import { useEffect, useRef, useState } from "react";
+
+type NavItem = { label: string; href: string } | { label: string; children: { label: string; href: string }[] };
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  const [servicesOpen, setServicesOpen] = useState(false);
+  const servicesRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (!servicesRef.current?.contains(e.target as Node)) setServicesOpen(false);
+    };
+    window.addEventListener("click", onClick);
+    return () => window.removeEventListener("click", onClick);
+  }, []);
+
+  const links = nav.links as NavItem[];
+
+  return (
+    <header className="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between p-3">
+        {/* Brand */}
+        <a href="/" className="text-xl font-extrabold tracking-tight">TMS Footballshop Berlin</a>
+
+        {/* Desktop nav */}
+        <div className="hidden md:flex items-center gap-6">
+          {links.map((l) => {
+            if (!("children" in l)) {
+              return (
+                <a key={(l as any).href} href={(l as any).href} className="text-sm font-medium hover:opacity-80">
+                  {(l as any).label}
+                </a>
+              );
+            }
+            // Services dropdown (desktop)
+            return (
+              <div key={(l as any).label} className="relative" ref={servicesRef}>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setServicesOpen((v) => !v); }}
+                  onKeyDown={(e) => e.key === "Escape" && setServicesOpen(false)}
+                  className="text-sm font-medium hover:opacity-80 inline-flex items-center gap-1"
+                  aria-haspopup="menu"
+                  aria-expanded={servicesOpen}
+                >
+                  {(l as any).label}
+                  <svg width="14" height="14" viewBox="0 0 24 24" className="opacity-70">
+                    <path d="M7 10l5 5 5-5" fill="none" stroke="currentColor" strokeWidth="2" />
+                  </svg>
+                </button>
+                {servicesOpen && (
+                  <div role="menu" className="absolute left-0 mt-2 w-56 rounded-xl border bg-white shadow-lg p-1">
+                    {(l as any).children?.map((c: any) => (
+                      <a key={c.href} href={c.href} className="block rounded-lg px-3 py-2 text-sm hover:bg-gray-100" role="menuitem">
+                        {c.label}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {/* Sales button (far right) */}
+          <a href={nav.sales.href} className="rounded-full px-4 py-2 text-sm font-semibold bg-black text-white hover:opacity-90 shadow">
+            {nav.sales.label}
+          </a>
+        </div>
+
+        {/* Mobile toggler */}
+        <button
+          className="md:hidden rounded-md border px-3 py-2 text-sm"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls="mobile-menu"
+          aria-label="Toggle menu"
+        >
+          Menu
+        </button>
+      </nav>
+
+      {/* Mobile menu */}
+      {open && (
+        <div id="mobile-menu" className="md:hidden border-t bg-white">
+          <div className="mx-auto max-w-6xl p-3 space-y-2">
+            {links.map((l) => {
+              if (!("children" in l)) {
+                return (
+                  <a key={(l as any).href} href={(l as any).href} className="block px-2 py-2 rounded-md hover:bg-gray-100">
+                    {(l as any).label}
+                  </a>
+                );
+              }
+              return <MobileServices key={(l as any).label} item={l as any} />;
+            })}
+            <a href={nav.sales.href} className="inline-flex w-full justify-center rounded-full px-4 py-2 text-sm font-semibold bg-black text-white hover:opacity-90">
+              {nav.sales.label}
+            </a>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}
+
+function MobileServices({ item }: { item: { label: string; children: { label: string; href: string }[] } }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-md">
+      <button className="w-full flex items-center justify-between px-2 py-2 rounded-md hover:bg-gray-100" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+        <span>{item.label}</span>
+        <svg width="16" height="16" viewBox="0 0 24 24" className={`transition ${open ? "rotate-180" : ""}`}>
+          <path d="M7 10l5 5 5-5" fill="none" stroke="currentColor" strokeWidth="2" />
+        </svg>
+      </button>
+      {open && (
+        <div className="ml-2 mt-1 space-y-1">
+          {item.children.map((c) => (
+            <a key={c.href} href={c.href} className="block px-2 py-2 rounded-md hover:bg-gray-100">
+              {c.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PromoSpotlight.tsx
+++ b/src/components/PromoSpotlight.tsx
@@ -1,0 +1,20 @@
+import sales from "@/data/sales.json";
+
+export default function PromoSpotlight() {
+  if (!sales.promos?.length) return null;
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-10">
+      <h2 className="text-2xl font-bold">Aktuelle Specials</h2>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {sales.promos.map((p, i) => (
+          <a key={i} href={p.href} className="group rounded-2xl border p-5 hover:shadow-lg transition">
+            <div className="text-lg font-semibold">{p.title}</div>
+            <div className="mt-2 inline-flex items-center gap-1 text-sm font-medium underline group-hover:no-underline">
+              {p.cta} →
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/SalesButton.tsx
+++ b/src/components/SalesButton.tsx
@@ -1,0 +1,15 @@
+"use client";
+import sales from "@/data/sales.json";
+
+export default function SalesButton() {
+  if (!sales.floatingButton?.enabled) return null;
+  return (
+    <a
+      href={sales.floatingButton.href}
+      className="fixed bottom-5 right-5 rounded-full px-5 py-3 font-semibold shadow-lg bg-black text-white hover:opacity-90"
+      aria-label="Sales"
+    >
+      {sales.floatingButton.label}
+    </a>
+  );
+}

--- a/src/components/SalesModal.tsx
+++ b/src/components/SalesModal.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useEffect, useState } from "react";
+import sales from "@/data/sales.json";
+
+const KEY = "tms_sales_last_seen"; // show once per day
+
+export default function SalesModal() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!sales.modal?.enabled) return;
+    const last = typeof window !== 'undefined' ? localStorage.getItem(KEY) : null;
+    const today = new Date().toDateString();
+    if (last !== today) {
+      setTimeout(() => setOpen(true), 800);
+    }
+  }, []);
+
+  const close = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(KEY, new Date().toDateString());
+    }
+    setOpen(false);
+  };
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/60 p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6">
+        <h3 className="text-xl font-bold">{sales.modal.headline}</h3>
+        <p className="mt-2 text-sm text-gray-700">{sales.modal.body}</p>
+        <div className="mt-5 flex items-center gap-3">
+          <a href={sales.modal.ctaHref} className="rounded-full bg-black px-4 py-2 text-white font-semibold">
+            {sales.modal.ctaText}
+          </a>
+          <button onClick={close} className="rounded-full border px-4 py-2 font-semibold">
+            Später
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SocialFloat.tsx
+++ b/src/components/SocialFloat.tsx
@@ -1,0 +1,33 @@
+"use client";
+import nav from "@/data/nav.json";
+
+const icons: Record<string, JSX.Element> = {
+  instagram: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm5 5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Zm6-1a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" fill="currentColor"/>
+    </svg>
+  ),
+  facebook: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path d="M13 22v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3V2h-3a5 5 0 0 0-5 5v3H6v4h3v8h4z" fill="currentColor"/>
+    </svg>
+  ),
+  x: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path d="M4 4l7.5 8.5L4 20h3l7.5-7.5L20 20h0l-7.5-8.5L20 4h-3l-6.5 6.5L7 4H4z" fill="currentColor"/>
+    </svg>
+  )
+};
+
+export default function SocialFloat() {
+  if (!nav.socials?.length) return null;
+  return (
+    <div className="fixed left-4 top-1/2 -translate-y-1/2 hidden md:flex flex-col gap-3 z-40" aria-label="Social media links">
+      {nav.socials.map((s) => (
+        <a key={s.href} href={s.href} target="_blank" rel="noopener noreferrer" className="grid place-items-center h-10 w-10 rounded-full bg-black text-white shadow hover:opacity-90" aria-label={s.label} title={s.label}>
+          {icons[s.icon] ?? <span className="text-xs">{s.label[0]}</span>}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -1,0 +1,23 @@
+{
+  "links": [
+    { "label": "Home", "href": "/" },
+    { "label": "Shop", "href": "https://your-shopify-domain.com" },
+    {
+      "label": "Services",
+      "children": [
+        { "label": "O-Zone Power Cleaning", "href": "/#service-ozone" },
+        { "label": "Consulting", "href": "/#service-consulting" },
+        { "label": "Reconditioning", "href": "/#service-reconditioning" }
+      ]
+    },
+    { "label": "Gallery", "href": "/#gallery" },
+    { "label": "Contact Us", "href": "/#contact" }
+  ],
+  "shop": { "label": "Shop", "href": "https://your-shopify-domain.com" },
+  "sales": { "label": "Sales", "href": "https://your-shopify-domain.com/collections/sale" },
+  "socials": [
+    { "label": "Instagram", "href": "https://instagram.com/your-handle", "icon": "instagram" },
+    { "label": "Facebook", "href": "https://facebook.com/your-page", "icon": "facebook" },
+    { "label": "X", "href": "https://x.com/your-handle", "icon": "x" }
+  ]
+}

--- a/src/data/sales.json
+++ b/src/data/sales.json
@@ -1,0 +1,19 @@
+{
+  "announcement": "Saisonstart-Angebote diese Woche!",
+  "promos": [
+    { "title": "Helme -15%", "cta": "Zum Shop", "href": "https://your-shopify-domain.com/collections/helmets" },
+    { "title": "Shoulderpads -10%", "cta": "Jetzt sparen", "href": "https://your-shopify-domain.com/collections/shoulder-pads" }
+  ],
+  "modal": {
+    "enabled": true,
+    "headline": "Neue Specials!",
+    "body": "Sichere dir Saison-Deals solange der Vorrat reicht.",
+    "ctaText": "Angebote ansehen",
+    "ctaHref": "https://your-shopify-domain.com/collections/sale"
+  },
+  "floatingButton": {
+    "enabled": true,
+    "label": "Sales",
+    "href": "https://your-shopify-domain.com/collections/sale"
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body { height: 100%; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js landing page with Tailwind CSS
- add dynamic navbar, promo spotlight, and sales modal
- configure CI pipeline for type-checking and builds

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run type-check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a87dae0832c951399460d587d82